### PR TITLE
Exibe o nome personalizado do método de entrega, ao invés do nome estático.

### DIFF
--- a/assets/js/woocommerce-correios-calculo-de-frete-na-pagina-do-produto-public.js
+++ b/assets/js/woocommerce-correios-calculo-de-frete-na-pagina-do-produto-public.js
@@ -106,18 +106,18 @@
 		 			}
 		 			var row = '';
 		 			// Tem Retirar no local?
-		 			if (result.retirar_no_local == 'sim') {
+		 			if (result.retirar_no_local.length) {
 	 					row += '<tr>\
-		                            <td>Retirar no local</td>\
+		                            <td>'+ result.retirar_no_local +'</td>\
 		                            <td>Grátis</td>\
 		                            <td>-</td>\
 	                        	</tr>';
+						
                     }
-
 		 			// Tem Frete Grátis?
-		 			if (result.frete_gratis == 'sim') {
+		 			if (result.frete_gratis.length) {
 	 					row += '<tr>\
-		                            <td>Frete Grátis</td>\
+		                            <td>'+ result.frete_gratis +'</td>\
 		                            <td>Grátis</td>\
 		                            <td>-</td>\
 	                        	</tr>';

--- a/src/CFPP_Shipping_Zones.php
+++ b/src/CFPP_Shipping_Zones.php
@@ -91,7 +91,7 @@ class CFPP_Shipping_Zones {
                 // Retirar no local?
                 if (get_class($shipping_method) == 'WC_Shipping_Local_Pickup') {
                     if ($shipping_method->enabled == 'yes' && $cep_destinatario_permitido) {
-                        $metodos_de_entrega['retirar_no_local'] = 'sim';
+                        $metodos_de_entrega['retirar_no_local'] = $shipping_method->title;
                     }
                     continue;
                 }
@@ -100,11 +100,11 @@ class CFPP_Shipping_Zones {
                 if (get_class($shipping_method) == 'WC_Shipping_Free_Shipping') {
                     if ($cep_destinatario_permitido) {
                         if (empty($shipping_method->requires)) {
-                            $metodos_de_entrega['frete_gratis'] = 'sim';
+                            $metodos_de_entrega['frete_gratis'] = $shipping_method->title;
                         } elseif ($shipping_method->requires == 'min_amount' || $shipping_method->requires == 'either') {
                             if (is_numeric($shipping_method->min_amount)) {
                                 if ($preco_produto > $shipping_method->min_amount) {
-                                    $metodos_de_entrega['frete_gratis'] = 'sim';
+                                    $metodos_de_entrega['frete_gratis'] = $shipping_method->title;
                                 }
                             }
                         }


### PR DESCRIPTION
Com esta alteração, será exibido o nome personalizado do método de entrega que foi definido pelo usuário na seção de "áreas de entrega" para o frete grátis e retirada no local, ao invés de exibir apenas de forma estática "Frete grátis" e "Retirar no local".