### PR TITLE
Verificação condicional do frete grátis

### DIFF
--- a/src/CFPP_Shipping_Zones.php
+++ b/src/CFPP_Shipping_Zones.php
@@ -113,7 +113,7 @@ class CFPP_Shipping_Zones {
                                 $metodos_de_entrega['frete_gratis'] = 'sim';
                             } elseif ($shipping_method->requires == 'min_amount' || $shipping_method->requires == 'either') {
                                 if (is_numeric($shipping_method->min_amount)) {
-                                    if ($preco_produto > $shipping_method->min_amount) {
+                                    if ($preco_produto >= $shipping_method->min_amount) {
                                         $metodos_de_entrega['frete_gratis'] = 'sim';
                                     }
                                 }


### PR DESCRIPTION
A verificação da quantia mínima para exibir o frete grátis deve ser "maior ou igual", não "maior que". Atualmente está verificando apenas valores maiores que o valor definido para o frete grátis.
Exemplo prático: Se definido um valor mínimo de R$30,00 para frete grátis e o produto possuir este mesmo valor (R$30,00), com a atual verificação, não irá entrar na condicional, e consequentemente não será exibido o frete grátis na tabela. Mas se for R$30,01, será.