### PR TITLE
consertar erro da página do produto quando o peso não está definido

### DIFF
--- a/src/Woocommerce_Correios_Calculo_De_Frete_Na_Pagina_Do_Produto.php
+++ b/src/Woocommerce_Correios_Calculo_De_Frete_Na_Pagina_Do_Produto.php
@@ -257,7 +257,9 @@ class Woocommerce_Correios_Calculo_De_Frete_Na_Pagina_Do_Produto {
                 break;
         }
 
-        return number_format($peso / $fator, 2, '.', ',');
+
+        return $peso ? number_format($peso / $fator, 2, '.', ',') : 0;
+        
     }
 
     /**


### PR DESCRIPTION
![product-page-error](https://user-images.githubusercontent.com/40926976/45903297-8efabb80-bdbf-11e8-8f5a-fcbe3a2c88e6.PNG)
