### PR TITLE
Adicionado value no response do REST

### DIFF
--- a/src/Shipping/ShippingMethods/Handlers/WC_Correios_Shipping_Carta_Registrada.php
+++ b/src/Shipping/ShippingMethods/Handlers/WC_Correios_Shipping_Carta_Registrada.php
@@ -24,6 +24,7 @@ class WC_Correios_Shipping_Carta_Registrada extends Handler
 
         $this->response->setDays($days);
         $this->response->setPrice($price);
+        $this->response->setValue($price);
     }
 
     /**

--- a/src/Shipping/ShippingMethods/Handlers/WC_Correios_Through_Webservice.php
+++ b/src/Shipping/ShippingMethods/Handlers/WC_Correios_Through_Webservice.php
@@ -30,6 +30,7 @@ class WC_Correios_Through_Webservice extends Handler
         if ($reflection_response['Erro'] == "0" || $reflection_response['Erro'] == "011") {
             $this->response->setDays($reflection_response['PrazoEntrega']);
             $this->response->setPrice($reflection_response['Valor']);
+            $this->response->setValue($reflection_response['Valor']);
             $this->response->setDebug($reflection_response);
         } else {
             throw HandlerException::webservice_error($reflection_response['MsgErro']);

--- a/src/Shipping/ShippingMethods/Handlers/WC_Shipping_Flat_Rate.php
+++ b/src/Shipping/ShippingMethods/Handlers/WC_Shipping_Flat_Rate.php
@@ -59,6 +59,7 @@ class WC_Shipping_Flat_Rate extends Handler
 
             $this->response->setDays(__('Contact us', 'woo-correios-calculo-de-frete-na-pagina-do-produto'));
             $this->response->setPrice($sum);
+            $this->response->setValue($sum);
         } else {
             throw HandlerException::unexpected_result_exception($sum);
         }

--- a/src/Shipping/ShippingMethods/Handlers/WC_Shipping_Free_Shipping.php
+++ b/src/Shipping/ShippingMethods/Handlers/WC_Shipping_Free_Shipping.php
@@ -24,6 +24,7 @@ class WC_Shipping_Free_Shipping extends Handler
         if ($should_show) {
             $this->response->setDays(__('Contact us', 'woo-correios-calculo-de-frete-na-pagina-do-produto'));
             $this->response->setPrice(0);
+            $this->response->setValue(0);
         } else {
             throw HandlerException::unexpected_result_exception(__('Does not meet free shipping requirements.', 'woo-correios-calculo-de-frete-na-pagina-do-produto'));
         }

--- a/src/Shipping/ShippingMethods/Handlers/WC_Shipping_Local_Pickup.php
+++ b/src/Shipping/ShippingMethods/Handlers/WC_Shipping_Local_Pickup.php
@@ -20,6 +20,7 @@ class WC_Shipping_Local_Pickup extends Handler
         $cost = is_numeric($this->shipping_method->cost) ? $this->shipping_method->cost : 0;
 
         $this->response->setPrice($cost);
+        $this->response->setValue($cost);
         $this->response->setDays(__('Contact us', 'woo-correios-calculo-de-frete-na-pagina-do-produto'));
     }
 }

--- a/src/Shipping/ShippingMethods/Response.php
+++ b/src/Shipping/ShippingMethods/Response.php
@@ -23,6 +23,8 @@ class Response
         $this->days = __('Undefined', 'woo-correios-calculo-de-frete-na-pagina-do-produto');
         $this->status = __('Undefined', 'woo-correios-calculo-de-frete-na-pagina-do-produto');
         $this->debug = '';
+        $this->value = '';
+        $this->id = $shipping_method->id;
     }
 
     /**

--- a/src/Shipping/ShippingMethods/Response.php
+++ b/src/Shipping/ShippingMethods/Response.php
@@ -61,6 +61,15 @@ class Response
 
         $this->price = $price;
     }
+    
+    /**
+     * @param $value
+     * @throws ResponseException
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
 
     /**
      * @param $debug


### PR DESCRIPTION
Olá @Luc45,

Obrigado por este plugin! É muito útil!
Enquanto eu fuçava nele, descobri que ele era compatível com a API Rest. Investigando mais além, vi que ele apenas retornava o `price` para mostrar na calculadora, mas não mostrava o `price` sem o `wc_price` aplicado, o que pode ser útil para quem quer utilizar a chamada via Rest.

Então, adicionei o node `value` no response para que a chamada tenha o valor do shipping method sem o filtro do `wc_price`:

![image](https://user-images.githubusercontent.com/246373/88469767-1f7a1980-cecb-11ea-97ca-f2fc44e92312.png)


Obrigado!