### PR TITLE
Adicionar filtro antes de enviar a resposta

### DIFF
--- a/src/Rest.php
+++ b/src/Rest.php
@@ -97,6 +97,7 @@ class Rest
 	        	return new WP_REST_Response( Performance_Profiler::$instance->get_timings() );
 	        }
 
+            $response = apply_filters('cfpp_modify_calculate_success_response', $response);
             do_action('cfpp_before_send_calculate_success_response', $response);
             return new WP_REST_Response($response);
 


### PR DESCRIPTION
Permitir que a resposta de sucesso seja modificada, antes de ser enviada para o front-end.